### PR TITLE
Use numeric input type for duration field in Care Portal

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -314,7 +314,7 @@
                         <label><br><span class="translate">Measurement Method</span><br></label>
                         <label for="meter">
                             <input type="radio" name="glucoseType" id="meter" value="Finger"/>
-                            <span class="translate">Meter</span>
+                            <span class="translate">Finger</span>
                         </label>
                         <label for="sensor">
                             <input type="radio" name="glucoseType" id="sensor" value="Sensor"/>
@@ -337,7 +337,7 @@
                     </label>
                     <label id="durationLabel" for="duration" class="left-column short-label">
                         <span class="translate">Duration</span>
-                        <input id="duration" placeholder="Duration in minutes" class="titletranslate"/>
+                        <input type="number" step="any" min="0" id="duration" placeholder="Duration in minutes" class="titletranslate" pattern="\d*" />
                     </label>
                     <label id="percentLabel" for="percent" class="left-column short-label">
                         <span class="translate">Percent</span>


### PR DESCRIPTION
Updated input type for Duration field for ease of use on mobile.
Relabelled "Meter" to "Finger" for Measurement Method field